### PR TITLE
chore(ci): remove pre-commit build step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
          git-message: 'chore(release): {version}'
          preset: 'angular'
          tag-prefix: 'v'
-         pre-commit: "pnpm run build"
          
      - name: Create Release Pull Request
        if: ${{ steps.changelog.outputs.skipped == 'false' }}


### PR DESCRIPTION
# Description

This commit eliminates the pre-commit build step in the GitHub Actions release workflow, streamlining the process for creating release pull requests.

Fixes # (issue)

---

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] 
---

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

---

## Additional Context

Add any other context or screenshots about the pull request here.
